### PR TITLE
Tarefas de Cadastro (#29) e Autenticação (#32)

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -46,7 +46,6 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
@@ -85,7 +84,6 @@
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -114,5 +112,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/backend/src/main/java/com/soulsurf/backend/config/WebSecurityConfig.java
+++ b/backend/src/main/java/com/soulsurf/backend/config/WebSecurityConfig.java
@@ -1,0 +1,41 @@
+package com.soulsurf.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
+        return authConfig.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth ->
+                        // Nossos endpoints de autenticação serão públicos
+                        auth.requestMatchers("/api/auth/**").permitAll()
+                                // Todas as outras requisições precisarão de autenticação
+                                .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/soulsurf/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/soulsurf/backend/repository/UserRepository.java
@@ -1,4 +1,12 @@
 package com.soulsurf.backend.repository;
 
-public class UserRepository {
+import com.soulsurf.backend.entities.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
 }


### PR DESCRIPTION
Este PR finaliza as funcionalidades de cadastro e login de usuário.

**Alterações:**
- Cria o endpoint `POST /api/auth/signup` para registro de novos usuários.
- Adiciona a configuração base do Spring Security (`WebSecurityConfig`), resolvendo erros de injeção de dependência.
- Assegura que o endpoint `POST /api/auth/login` está funcional.
- Corrige a definição do `UserRepository`.

Resolve #29
Resolve #32