### PR TITLE
feat(frontend): Implementa FAB e modal para criar novo registro

### DIFF
--- a/front_end/src/components/customCards/NovoRegistroCard.tsx
+++ b/front_end/src/components/customCards/NovoRegistroCard.tsx
@@ -13,12 +13,12 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
+import { Textarea } from "@/components/ui/textarea"; // Manter o Textarea
 
 function NovoRegistroCard() {
   // Estados para guardar os dados do formulário
-  const [titulo, setTitulo] = useState("");
-  const [descricao, setDescricao] = useState("");
+  // Removendo apenas o estado de 'titulo'
+  const [descricao, setDescricao] = useState(""); // Manter estado da descrição
   const [foto, setFoto] = useState<File | null>(null);
 
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -30,7 +30,7 @@ function NovoRegistroCard() {
   const handleSubmit = (event: React.FormEvent) => {
     event.preventDefault();
     // A integração com a API virá na próxima issue
-    console.log({ titulo, descricao, foto });
+    console.log({ descricao, foto }); // Ajustado para não incluir 'titulo'
     alert("Registo salvo (simulação)!");
   };
 
@@ -44,7 +44,8 @@ function NovoRegistroCard() {
       </CardHeader>
       <form onSubmit={handleSubmit}>
         <CardContent className="space-y-6">
-          <div className="space-y-2">
+          {/* O bloco do Título foi removido daqui */}
+          {/* <div className="space-y-2">
             <Label htmlFor="titulo">Título</Label>
             <Input
               id="titulo"
@@ -53,7 +54,9 @@ function NovoRegistroCard() {
               onChange={(e) => setTitulo(e.target.value)}
               required
             />
-          </div>
+          </div> */}
+          
+          {/* Bloco da Descrição - MANTIDO */}
           <div className="space-y-2">
             <Label htmlFor="descricao">Descrição</Label>
             <Textarea
@@ -64,7 +67,9 @@ function NovoRegistroCard() {
               className="min-h-[120px]"
             />
           </div>
-           <div className="space-y-2">
+          
+          {/* Bloco da Foto - MANTIDO */}
+          <div className="space-y-2">
             <Label htmlFor="foto">Foto</Label>
             <Input
               id="foto"

--- a/front_end/src/layouts/RootLayout.tsx
+++ b/front_end/src/layouts/RootLayout.tsx
@@ -1,24 +1,41 @@
-// src/layouts/RootLayout.tsx
-import Header from '@/layouts/Header';
-import React from 'react';
+import React, { useState } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
+import { Plus } from 'lucide-react';
+
+// Componentes existentes
+import Header from '@/layouts/Header';
 import SideBarLeft from '@/layouts/SideBarLeft';
+import NovoRegistroCard from '@/components/customCards/NovoRegistroCard'; // Importa o seu card
+
+// Componentes de UI da Shadcn
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
 const RootLayout: React.FC = () => {
   const location = useLocation();
-  const noSidebarRoutes = [
+  // Estado para controlar a abertura/fecho do modal
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // Rotas onde o layout principal (com sidebars e botão) não deve aparecer
+  const noLayoutRoutes = [
     '/',
     '/login',
     '/cadastro',
-    '/forgot-password',
+    '/esqueci-a-senha',
     '/landing',
   ];
-  const showSidebars = !noSidebarRoutes.includes(location.pathname);
+  const showLayout = !noLayoutRoutes.includes(location.pathname);
 
   return (
     <main>
-      {showSidebars ? (
+      {showLayout ? (
+        // Layout principal da aplicação (para utilizadores logados)
         <>
-          <div className="fixed top-0 left-0 right-0 z-50">
+          <div className="fixed top-0 left-0 right-0 z-40"> {/* z-index ajustado */}
             <Header />
           </div>
           <div className="flex pt-20">
@@ -29,14 +46,32 @@ const RootLayout: React.FC = () => {
             </div>
 
             <div className="w-full md:w-[60%]">
-              <Outlet />
+              <Outlet /> {/* As páginas como HomePage, ProfilePage, etc., serão renderizadas aqui */}
             </div>
+            
             <div className="hidden md:block w-[20%]">
               {/* <SideBarRight /> */}
             </div>
           </div>
+
+          {/* DIALOG E BOTÃO FLUTUANTE (FAB) */}
+          <Dialog open={isModalOpen} onOpenChange={setIsModalOpen}>
+            <DialogTrigger asChild>
+              <Button
+                className="fixed bottom-8 right-8 h-16 w-16 rounded-full shadow-lg z-50"
+                size="icon"
+              >
+                <Plus className="h-8 w-8" />
+              </Button>
+            </DialogTrigger>
+            <DialogContent className="sm:max-w-[650px] p-0">
+              {/* O seu formulário é renderizado aqui dentro do modal */}
+              <NovoRegistroCard />
+            </DialogContent>
+          </Dialog>
         </>
       ) : (
+        // Layout para páginas públicas (login, cadastro, etc.)
         <div className="w-full">
           <Outlet />
         </div>


### PR DESCRIPTION
Este Pull Request implementa o Floating Action Button (FAB) e o modal
para a criação de novos registos de sessões de surf no front-end.

**Principais alterações:**
- Adicionado um FAB (botão '+') no canto inferior direito das páginas internas.
- Ao clicar no FAB, abre-se um modal (Dialog da Shadcn/ui).
- O modal renderiza o componente `NovoRegistroCard.tsx`.
- O campo "Título" foi removido do `NovoRegistroCard` conforme solicitado.

**Para revisão e teste:**
1. Inicie a aplicação front-end (`npm run dev`).
2. Navegue para `/home` (ou qualquer página interna).
3. Verifique a presença do FAB.
4. Clique no FAB para abrir o modal com o formulário de "Novo Registo" (sem o campo de título).