### PR TITLE
feat(frontend): Implementa modal de configuracoes na SidebarLeft

### DIFF
--- a/front_end/src/layouts/SideBarLeft.tsx
+++ b/front_end/src/layouts/SideBarLeft.tsx
@@ -1,5 +1,8 @@
-import React from 'react';
+// src/layouts/SideBarLeft.tsx (Versão Atualizada com Modal de Configurações)
+import React, { useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+
+// Ícones existentes e novos para as opções de configuração
 import {
   Home,
   Compass,
@@ -7,11 +10,27 @@ import {
   Users,
   MessageSquare,
   Bell,
-  User,
-  Settings,
+  User,        // Para Perfil / Editar Perfil
+  Settings,    // Para Configurações (o próprio gatilho)
+  ShieldCheck, // Exemplo: Para Mudar Senha
+  LogOut,      // Para Sair
+  Mail,        // Exemplo: Para Notificações (opcional, pode ser Bell)
 } from 'lucide-react';
-import { Button } from '@/components/ui/button';
 
+// Componentes de UI da Shadcn/ui
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Card, CardContent } from "@/components/ui/card";
+// Removida a importação de Avatar, pois não é utilizada neste ficheiro
+// import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+
+// Tipagem para os itens de navegação
 interface NavItemProps {
   href: string;
   icon: React.ElementType;
@@ -29,7 +48,14 @@ const navItems: NavItemProps[] = [
 ];
 
 const SidebarLeft: React.FC = () => {
-  const location = useLocation(); 
+  const location = useLocation();
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false); // Estado para controlar o modal
+
+  // Função para lidar com o logout
+  const handleLogout = () => {
+    localStorage.removeItem('token');
+    window.location.href = '/'; // Redireciona para a página inicial
+  };
 
   return (
     <aside className="w-80 h-[90%] flex flex-col justify-between p-4 bg-white border-r border-gray-200">
@@ -55,29 +81,79 @@ const SidebarLeft: React.FC = () => {
         </ul>
       </nav>
 
-      {/* parte de baixo configurações */}
+      {/* PARTE DE BAIXO: CONFIGURAÇÕES E SAIR (AGORA NO MODAL) */}
       <div>
-        <Link to="/configuracoes">
-          <Button
-            variant={
-              location.pathname === '/configuracoes' ? 'secondary' : 'ghost'
-            }
-            className="w-full justify-start text-md py-6 mb-2 hover:cursor-pointer"
-          >
-            <Settings className="mr-3 h-5 w-5" />
-            Configurações
-          </Button>
-        </Link>
-          <Button
-              onClick={() => {
-                  localStorage.removeItem('token');
-                  window.location.href = '/';
-              }}
-              variant="ghost"
-              className="w-full justify-start text-md py-6 hover:cursor-pointer"
-          >
-              Sair
-          </Button>
+        <Dialog open={isSettingsOpen} onOpenChange={setIsSettingsOpen}>
+          <DialogTrigger asChild>
+            {/* Botão "Configurações" que abre o modal */}
+            <Button
+              variant={
+                location.pathname === '/configuracoes' || isSettingsOpen
+                  ? 'secondary'
+                  : 'ghost'
+              }
+              className="w-full justify-start text-md py-6 mb-2 hover:cursor-pointer"
+            >
+              <Settings className="mr-3 h-5 w-5" />
+              Configurações
+            </Button>
+          </DialogTrigger>
+
+          <DialogContent className="sm:max-w-[425px]">
+            <DialogHeader>
+              <DialogTitle>Configurações</DialogTitle>
+            </DialogHeader>
+            <Card className="border-none shadow-none">
+              <CardContent className="p-2 space-y-1">
+                {/* Opção 1: Editar Perfil */}
+                <Button 
+                  variant="ghost" 
+                  className="w-full justify-start p-4 text-md hover:cursor-pointer"
+                  onClick={() => {
+                    alert("A navegar para Editar Perfil...");
+                    setIsSettingsOpen(false); // Fecha o modal após a ação
+                  }}
+                >
+                  <User className="mr-3 h-5 w-5" />
+                  Editar Perfil
+                </Button>
+                {/* Opção 2: Mudar Senha */}
+                <Button 
+                  variant="ghost" 
+                  className="w-full justify-start p-4 text-md hover:cursor-pointer"
+                  onClick={() => {
+                    alert("A navegar para Mudar Senha...");
+                    setIsSettingsOpen(false); // Fecha o modal após a ação
+                  }}
+                >
+                  <ShieldCheck className="mr-3 h-5 w-5" />
+                  Mudar Senha
+                </Button>
+                {/* Opção 3: Notificações */}
+                <Button 
+                  variant="ghost" 
+                  className="w-full justify-start p-4 text-md hover:cursor-pointer"
+                  onClick={() => {
+                    alert("A navegar para Notificações...");
+                    setIsSettingsOpen(false); // Fecha o modal após a ação
+                  }}
+                >
+                  <Mail className="mr-3 h-5 w-5" /> {/* Usei Mail, mas pode ser Bell */}
+                  Notificações
+                </Button>
+                {/* Opção 4: Sair (Logout) - com estilo distinto */}
+                <Button 
+                  variant="ghost" 
+                  className="w-full justify-start p-4 text-md text-red-600 hover:text-red-700 hover:bg-red-50 hover:cursor-pointer"
+                  onClick={handleLogout} // Chama a função de logout
+                >
+                  <LogOut className="mr-3 h-5 w-5" />
+                  Sair
+                </Button>
+              </CardContent>
+            </Card>
+          </DialogContent>
+        </Dialog>
       </div>
     </aside>
   );


### PR DESCRIPTION
Este Pull Request adiciona a funcionalidade de um modal de configurações no menu lateral esquerdo.

**Principais alterações:**
- O botão "Configurações" na `SidebarLeft` agora abre um modal (Dialog da Shadcn/ui) em vez de navegar para uma nova página.
- O modal inclui as seguintes opções:
    - Editar Perfil (placeholder)
    - Mudar Senha (placeholder)
    - Notificações (placeholder)
    - Sair (funcionalidade de logout existente)
- Cada opção tem um ícone da `lucide-react` e o botão "Sair" tem um estilo visual distinto.
- O componente `Dialog` da Shadcn/ui foi adicionado ao projeto.

**Para revisão e teste:**
1. Certifique-se de que o back-end está a correr na porta 8080 (se relevante para algum teste subsequente).
2. Inicie a aplicação front-end (`npm run dev`) na branch `feature/modal-configuracoes`.
3. Navegue para qualquer página interna da aplicação (ex: `/home`).
4. Clique no botão "Configurações" no menu lateral esquerdo.
5. Verifique se o modal é aberto corretamente com todas as opções listadas.
6. Teste as opções "Editar Perfil", "Mudar Senha", "Notificações" (elas devem mostrar um `alert()`).
7. Teste a opção "Sair" para confirmar que efetua o logout e redireciona para a página inicial.
8. Confirme que o modal pode ser fechado clicando no 'X' ou fora da área do modal.