### PR TITLE
feat: Implementa feed 'Seguindo' e corrige exibição de comentários

### DIFF
--- a/backend/src/main/java/com/soulsurf/backend/repository/PostRepository.java
+++ b/backend/src/main/java/com/soulsurf/backend/repository/PostRepository.java
@@ -14,9 +14,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findByPublicoIsTrueOrderByDataDesc();
     List<Post> findByUsuarioOrderByDataDesc(User usuario);
     List<Post> findByBeachOrderByDataDesc(Beach beach);
-    
+
+    List<Post> findByUsuarioInOrderByDataDesc(List<User> usuarios);
+
     @Query("SELECT p FROM Post p WHERE p.beach = ?1 AND (p.publico = true OR p.usuario.email = ?2)")
     Page<Post> findByBeachAndPublicoIsTrueOrUsuarioEmail(Beach beach, String userEmail, Pageable pageable);
-    
+
     Page<Post> findByBeachAndPublicoIsTrue(Beach beach, Pageable pageable);
 }


### PR DESCRIPTION
Este PR introduz uma nova funcionalidade de feed, permitindo que os usuários vejam apenas os posts das pessoas que seguem, e também corrige um bug crítico na exibição de comentários aninhados.

**1. Nova Funcionalidade: Feed 'Seguindo'**
- **Nova Rota:** Adicionado o endpoint `GET /api/posts/following`. Este endpoint é seguro e requer autenticação.
- **Lógica de Serviço:** Implementado um novo método `getFollowingPosts` no `PostService` que:
    - Identifica o usuário autenticado.
    - Recupera a lista de usuários que ele segue.
    - Busca e retorna todos os posts desses usuários em ordem cronológica inversa.
- **Repositório:** O `PostRepository` foi estendido com um método para buscar posts de uma coleção de usuários (`findByUsuarioInOrderByDataDesc`).

**2. Correção de Bug (Comentários Aninhados):**
- **Problema:** A conversão de `Post` para `PostDTO` no `PostService` não estava processando corretamente a estrutura de respostas aninhadas dos comentários, resultando em uma lista "plana" e ignorando as threads.
- **Solução:** A lógica de conversão foi refatorada para usar um método recursivo (`convertCommentToDto`). Isso garante que a hierarquia de comentários e respostas seja corretamente preservada nos DTOs de Post em **toda a aplicação** (feed principal, feed de usuário e o novo feed 'Seguindo').

Com estas alterações, a experiência do usuário é significativamente melhorada, oferecendo um feed personalizado e garantindo que as discussões nos comentários sejam exibidas corretamente.