### PR TITLE
feat: adiciona campos admin e banned no UserDTO para identificação no front-end

### DIFF
--- a/backend/src/main/java/com/soulsurf/backend/dto/UserDTO.java
+++ b/backend/src/main/java/com/soulsurf/backend/dto/UserDTO.java
@@ -16,6 +16,8 @@ public class UserDTO {
     private int seguidoresCount;
     private int seguindoCount;
     private List<PostDTO> posts;
+    private boolean admin;
+    private boolean banned;
 
     public UserDTO() {
     }

--- a/backend/src/main/java/com/soulsurf/backend/services/UserService.java
+++ b/backend/src/main/java/com/soulsurf/backend/services/UserService.java
@@ -228,6 +228,8 @@ public class UserService {
         userDTO.setFotoPerfil(user.getFotoPerfil());
         userDTO.setFotoCapa(user.getFotoCapa());
         userDTO.setBio(user.getBio());
+        userDTO.setAdmin(user.isAdmin());
+        userDTO.setBanned(user.isBanned());
         // Futuramente quando os posts estiverem prontos descomentar essa e trazer os posts para o perfil do usuario
         // userDTO.setPosts(user.getPosts().stream().map(this::convertToDto).collect(Collectors.toList()));
         // Para evitar recursão infinita, podemos usar um DTO mais simples ou apenas contar
@@ -250,7 +252,9 @@ public class UserService {
     userDTO.setFotoPerfil(user.getFotoPerfil());
     userDTO.setFotoCapa(user.getFotoCapa());
     userDTO.setBio(user.getBio());
-    
+    userDTO.setAdmin(user.isAdmin());
+    userDTO.setBanned(user.isBanned());
+
 
     if (user.getSeguidores() != null) {
         userDTO.setSeguidoresCount(user.getSeguidores().size());


### PR DESCRIPTION
# 🎯 Feature: Adicionar campos admin e banned no UserDTO

## 📋 Descrição

Esta PR adiciona os campos `admin` e `banned` no `UserDTO` para permitir que o front-end identifique se um usuário possui privilégios de administrador ou está banido da plataforma.

## 🔍 Problema

O front-end não conseguia identificar se um usuário é administrador ou está banido, pois essas informações não eram retornadas pela API nos endpoints de usuário. Isso impedia:

- Exibir funcionalidades administrativas na interface (painel de admin, botões de deletar/banir)
- Mostrar badges/indicadores visuais de admin nos perfis
- Controlar acesso a páginas administrativas no lado do cliente
- Bloquear interações com usuários banidos

## ✅ Solução

Adicionados os campos `admin` e `banned` ao `UserDTO` e atualizados os métodos de conversão para incluir essas informações em todas as respostas da API relacionadas a usuários.

## 🛠️ Alterações Realizadas

### 1. **UserDTO.java**
Adicionados dois novos campos booleanos:

```java
private boolean admin;
private boolean banned;
```

Esses campos são automaticamente serializados pelo Lombok (@Getter/@Setter) e aparecem no JSON de resposta.

### 2. **UserService.java**
Atualizados **dois métodos** de conversão de entidade para DTO:

#### a) Método `convertToDto(User user)`
Usado quando retorna perfil completo com posts. Adicionadas as linhas:

```java
userDTO.setAdmin(user.isAdmin());
userDTO.setBanned(user.isBanned());
```

#### b) Método `convertToDtoWithoutPosts(User user)`
Usado em listas (seguidores, seguindo). Adicionadas as mesmas linhas:

```java
userDTO.setAdmin(user.isAdmin());
userDTO.setBanned(user.isBanned());
```

## 📡 Endpoints Afetados

Todos os endpoints que retornam dados de usuário agora incluem os campos `admin` e `banned`:

| Endpoint | Descrição |
|----------|-----------|
| `GET /api/users/me` | Perfil do usuário autenticado |
| `GET /api/users/{id}` | Perfil de um usuário específico |
| `GET /api/users/{id}/followers` | Lista de seguidores (cada usuário com admin/banned) |
| `GET /api/users/{id}/following` | Lista de quem o usuário segue (cada um com admin/banned) |

## 📤 Exemplo de Resposta

### Antes:
```json
{
  "id": 1,
  "username": "JoaoSurfista",
  "email": "joao@example.com",
  "fotoPerfil": "https://...",
  "fotoCapa": "https://...",
  "bio": "Surfista apaixonado",
  "seguidoresCount": 150,
  "seguindoCount": 80,
  "posts": [...]
}
```

### Depois:
```json
{
  "id": 1,
  "username": "JoaoSurfista",
  "email": "joao@example.com",
  "fotoPerfil": "https://...",
  "fotoCapa": "https://...",
  "bio": "Surfista apaixonado",
  "seguidoresCount": 150,
  "seguindoCount": 80,
  "admin": true,      // ← NOVO
  "banned": false,    // ← NOVO
  "posts": [...]
}
```

## 🔐 Informações de Segurança

- ✅ **Nenhuma lógica de negócio foi alterada** - apenas exposição de dados existentes
- ✅ Os campos `admin` e `banned` **já existiam** na entidade `User` do banco de dados
- ✅ Não há risco de vazamento de dados sensíveis - apenas flags booleanas públicas
- ⚠️ **Importante**: O controle de permissões no backend permanece intacto. Esses campos são apenas informativos para o front-end

## 🧪 Como Testar

### 1. Obter perfil do usuário autenticado
```bash
GET /api/users/me
Authorization: Bearer {seu-token-jwt}
```

**Resposta esperada**: JSON com campos `admin` e `banned`

### 2. Obter perfil de outro usuário
```bash
GET /api/users/1
```

**Resposta esperada**: JSON com campos `admin` e `banned`

### 3. Verificar no banco de dados
```sql
SELECT id, username, admin, banned FROM users WHERE id = 1;
```

Os valores retornados pela API devem corresponder aos valores do banco.

## 📦 Dependências

- ✅ Nenhuma nova dependência adicionada
- ✅ Compatível com a versão atual do Spring Boot
- ✅ Lombok continua gerando os getters/setters automaticamente

## ⚠️ Breaking Changes

❌ **Nenhum breaking change** - essa é uma alteração **retrocompatível**:
- Novos campos são adicionados, nenhum campo existente foi removido
- O front-end que não usar esses campos continuará funcionando normalmente
- Todos os endpoints existentes continuam funcionando da mesma forma

## 🎨 Uso no Front-End

### Exemplo React/JavaScript:

```javascript
// Verificar se usuário logado é admin
const user = await fetch('/api/users/me').then(r => r.json());

if (user.admin) {
  // Mostrar painel de administração
  showAdminPanel();
}

if (user.banned) {
  // Bloquear ações do usuário
  showBannedMessage();
}
```

### Exemplo de UI condicional:

```jsx
{userProfile.admin && (
  <span className="badge badge-admin">👑 Administrador</span>
)}

{userProfile.banned && (
  <div className="alert alert-danger">
    Este usuário está banido
  </div>
)}
```

## ✔️ Checklist

- [x] Código compilado sem erros
- [x] Nenhuma lógica de negócio foi alterada
- [x] Campos adicionados ao DTO
- [x] Métodos de conversão atualizados
- [x] Documentação inline (comentários) mantida
- [x] Compatibilidade retroativa garantida
- [x] Commit seguindo padrão conventional commits

## 📝 Notas Adicionais

- Os campos `admin` e `banned` na entidade `User` foram definidos com valores padrão `false`
- O Lombok gera automaticamente os métodos `isAdmin()` e `isBanned()` devido ao tipo `boolean`
- Esta alteração **não afeta** a segurança do backend - o controle de acesso deve continuar sendo feito no servidor